### PR TITLE
Fix IP address return upon droplet creation

### DIFF
--- a/droplet_setup.py
+++ b/droplet_setup.py
@@ -32,6 +32,10 @@ def create_droplet(api_token, droplet_name, region, size, image, ssh_keys):
             time.sleep(5)
             action.load()
     
+    while not droplet.ip_address:
+        droplet.load()
+        time.sleep(5)
+    
     return droplet
 
 def setup_ssh_keys(ssh_key_paths):


### PR DESCRIPTION
Add a loop to wait for the droplet to be assigned an IP address in the `create_droplet` function.

* Assign the public IP address to the `droplet` object in the `create_droplet` function
* Print the public IP address of the droplet in the `cli_entry` function